### PR TITLE
Fix/app bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .editorconfig
 .DS_Store
 .bowerrc
+*.tmp

--- a/README.md
+++ b/README.md
@@ -11,11 +11,23 @@ An experimental Origami component to implement a responsive crossword.
    * $ `npm install -g gulp`
    * $ `npm install -g origami-build-tools`
    * $ `npm install -g bower`
-   * $ `bower install`
+   * As described in https://origami.ft.com/docs/tutorials/manual-build/#bower--the-origami-registry
+      * ensure you have ~/.bowerrc configured with
+```
+{
+	"registry": {
+		"search": [
+			"https://origami-bower-registry.ft.com",
+			"https://registry.bower.io"
+		]
+	}
+}
+```
+   * $ `obt install`
    * $ `obt build`
 * deploy locally as described in the [Origami build tools doc](https://github.com/Financial-Times/origami-build-tools#developing-modules-locally)
    * $ `obt demo --runServer --watch`
-   * see a demo of it running at http://localhost:8080/demos/local/basic.html
+   * see a demo of it running at http://localhost:8999/demos/local/basic.html
 * [Bower linking a component](https://oncletom.io/2013/live-development-bower-component/)
 * general Origami [Developer Guide](http://origami.ft.com/docs/developer-guide/)
 

--- a/src/js/oCrossword.js
+++ b/src/js/oCrossword.js
@@ -547,6 +547,12 @@ OCrossword.prototype.assemble = function assemble() {
 
 
 		this.addEventListener(magicInput, 'keydown', function (e) {
+			const shiftKey = e.shiftKey;
+			const keyCode  = e.keyCode;
+			const magicInputValue = magicInput.value;
+			const isAndroidTF = isAndroid();
+
+			console.log(`DEBUG: this.addEventListener: magicInput: isAndroidTF=${JSON.stringify(isAndroidTF)}, shiftKey=${JSON.stringify(shiftKey)}, keyCode=${keyCode}, magicInputValue=${JSON.stringify(magicInputValue)}`);
 			if (!isAndroid()) {
 				e.preventDefault();
 			}
@@ -604,6 +610,9 @@ OCrossword.prototype.assemble = function assemble() {
 							e.target.select();
 						}
 					}); //a11y fix for screen reader
+				} else {
+					console.log(`DEBUG: this.addEventListener: magicInput: else: fudging for android ...`);
+
 				}
 
 				const clueId = currentlySelectedGridItem.direction[0].toUpperCase() + currentlySelectedGridItem.number;
@@ -611,11 +620,24 @@ OCrossword.prototype.assemble = function assemble() {
 
 				progress();
 			} else {
+				console.log(`DEBUG: this.addEventListener: magicInput: else: no keypress match ...`);
 
 			}
 		});
 
+		// when using the android keyboard, sometimes the e.target.value is updated silently (with keycode 229),
+		// and we can use this cached value to compare with to see if something has changed.
+		// [inputID] = "char"
+
+		let prevCluesElTargetValues = {};
+
 		this.addEventListener(cluesEl, 'keydown', function(e){
+			const inputID = e.target.getAttribute('data-link-identifier');
+			if (!prevCluesElTargetValues.hasOwnProperty(inputID)) {
+				prevCluesElTargetValues[inputID] = '';
+			}
+
+			console.log(`DEBUG: this.addEventListener: cluesEl: inputID=${inputID}, isAndroid=${JSON.stringify(isAndroid())}, e: shiftKey=${JSON.stringify(e.shiftKey)}, keyCode=${e.keyCode}, prevCluesElTargetValues[inputID]=${JSON.stringify(prevCluesElTargetValues[inputID])}`);
 			let timer = 0;
 
 			if (!isAndroid()) {
@@ -627,6 +649,7 @@ OCrossword.prototype.assemble = function assemble() {
 			}
 
 			if(e.target.nodeName !== 'INPUT') {
+				console.log(`DEBUG: this.addEventListener: cluesEl: e.target.nodeName=${JSON.stringify(e.target.nodeName)}`);
 				if(e.keyCode === 9) {
 					if(e.shiftKey) {
 						--currentClue;
@@ -686,6 +709,7 @@ OCrossword.prototype.assemble = function assemble() {
 					e.target.value = '';
 					nextInput(e.target, -1);
 					updateInBackground(e);
+					prevCluesElTargetValues[inputID] = e.target.value;
 				}, timer);
 
 				return;
@@ -702,40 +726,65 @@ OCrossword.prototype.assemble = function assemble() {
 
 				if(!isAndroid()) {
 					e.target.value = String.fromCharCode(e.keyCode);
+				} else {
+					console.log(`DEBUG: this.addEventListener: cluesEl: keycodes65-90, isAndroid=true, e.target.value=${JSON.stringify(e.target.value)}`);
 				}
 
 				e.target.select();
 
 				const identifier = e.target.getAttribute('data-link-identifier').split('-');
-				trackEvent({action: 'clueInput', clueId: identifier[0], letterId: identifier[1]});
+				const trackingEventDetails = {action: 'clueInput', clueId: identifier[0], letterId: identifier[1]};
+				trackEvent(trackingEventDetails);
 
 				setTimeout(function(){
-					nextInput(e.target, 1);
+					let direction = 1;
+					console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: start:           e.target.value=${JSON.stringify(e.target.value)}, direction=${direction}, prevCluesElTargetValues[${inputID}]=${JSON.stringify(prevCluesElTargetValues[inputID])}`);
+					// const direction = (isAndroid() && e.target.value == '')? -1 : 1;
+					if ( isAndroid() ) {
+						if (
+							 e.target.value === prevCluesElTargetValues[inputID]
+						|| e.target.value === ''
+						// || (e.target.value !== '' && prevCluesElTargetValues[inputID] === '')
+					) {
+							e.target.value = '';
+							direction = -1;
+						}
+						console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: isAndroid, so...: e.target.value=${JSON.stringify(e.target.value)}, direction=${direction}, prevCluesElTargetValues[${inputID}]=${JSON.stringify(prevCluesElTargetValues[inputID])}`);
+					}
+
+					console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: start:           e.target.value=${JSON.stringify(e.target.value)}, direction=${direction}, prevCluesElTargetValues[${inputID}]=${JSON.stringify(prevCluesElTargetValues[inputID])}`);
+					nextInput(e.target, direction);
+					console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: after nextInput: e.target.value=${JSON.stringify(e.target.value)}`);
 					updateInBackground(e);
+					prevCluesElTargetValues[inputID] = e.target.value;
 				}, timer);
 
 
 			} else {
-
+				console.log(`DEBUG: this.addEventListener: cluesEl: else: no keypress match ...`);
 			}
 		});
 
 		function updateInBackground(e) {
 			getCellFromClue(e.target, gridSync => {
+				console.log(`DEBUG: updateInBackground: getCellFromClue: gridSync=${JSON.stringify(gridSync)}, e.target.value='${e.target.value}'`);
 				gridSync.grid.textContent = e.target.value;
 
 				if(gridSync.defSync) {
 					const defSync = cluesEl.querySelector('input[data-link-identifier="' + gridSync.defSyncInput +'"]');
 					defSync.value = e.target.value;
+					prevCluesElTargetValues[gridSync.defSyncInput] = e.target.value;
 				}
 
 				updateScreenReaderAnswer(e.target, gridSync);
 			});
 		}
 
-		const progress = debounce(function progress(direction) {
+		const progress = debounce(function progress(direction=1) {
+			console.log(`DEBUG: progress: direction=${JSON.stringify(direction)}, magicInputTargetEl=${magicInputTargetEl}, magicInputNextEls=${magicInputNextEls}`);
 			direction = direction === -1 ? -1 : 1;
 			const oldMagicInputEl = magicInputTargetEl;
+			const magicInputValueAsSet = magicInput.value;
 
 			if (
 				magicInputTargetEl &&
@@ -749,12 +798,16 @@ OCrossword.prototype.assemble = function assemble() {
 			if (magicInputNextEls) {
 				const index = magicInputNextEls.indexOf(oldMagicInputEl);
 				syncPartialClue(magicInput.value, magicInputNextEls, index);
+				if (isAndroid() && magicInputValueAsSet === '') { // cos this is the sign that the android keyboard entry was a 'delete' key
+					console.log(`DEBUG: progress: after syncPartialClue: magicInputValueAsSet=${JSON.stringify(magicInputValueAsSet)}, so setting direction from ${JSON.stringify(direction)} to -1`);
+					direction = -1;
+				}
 				if (magicInputNextEls[index + direction]) {
 					return takeInput(magicInputNextEls[index + direction], magicInputNextEls);
 				}
+				unsetClue(magicInputNextEls.length, direction);
 			}
 
-			unsetClue(magicInputNextEls.length, direction);
 			magicInputNextEls = null;
 			magicInput.value = '';
 			blockHighlight = false;
@@ -817,14 +870,17 @@ OCrossword.prototype.assemble = function assemble() {
 		function nextInput(source, direction) {
 			const inputID = source.getAttribute('data-link-identifier');
 			const inputGroup = document.querySelectorAll('input[data-link-identifier^="' + inputID.split('-')[0] +'-"]');
-			let currentInput = inputID.split('-')[1];
-			const newInput = direction === 1?++currentInput:--currentInput;
+			const currentInput = parseInt(inputID.split('-')[1]);
+			const newInput = direction === 1?(currentInput+1):(currentInput-1);
+			console.log(`DEBUG: nextInput: inputID=${JSON.stringify(inputID)}, direction=${direction}, currentInput=${currentInput}, newInput=${newInput}, inputGroup.length=${inputGroup.length}`);
 
 			if(newInput >= 0 && newInput < inputGroup.length) {
+				console.log(`DEBUG: nextInput: next.focus and next.select`);
 				const next = cluesEl.querySelector('input[data-link-identifier="' + inputID.split('-')[0] +'-'+ newInput+'"]');
 				next.focus();
 				next.select();
 			} else {
+				console.log(`DEBUG: nextInput: source.blur`);
 				source.blur();
 				const def = source.parentElement.parentElement;
 				const inputs = cluesEl.querySelectorAll('input');
@@ -882,6 +938,7 @@ OCrossword.prototype.assemble = function assemble() {
 			const defDirection = inputIdentifier.slice(0,1) === 'A'?'across':'down';
 			const defNum = inputIdentifier.slice(1,inputIdentifier.length).split('-')[0];
 			const defIndex = parseInt(inputIdentifier.split('-')[1], 10);
+			console.log(`DEBUG: getCellFromClue: inputIdentifier=${inputIdentifier}, defDirection=${defDirection}, defNum=${defNum}, defIndex=${defIndex}`);
 
 			const selectedCell = {};
 
@@ -901,6 +958,8 @@ OCrossword.prototype.assemble = function assemble() {
 					}
 				}
 			}
+
+			console.log(`DEBUG: getCellFromClue: selectedCell=${JSON.stringify(selectedCell)}`);
 
 			callback(selectedCell);
 		}
@@ -1009,17 +1068,26 @@ OCrossword.prototype.assemble = function assemble() {
 		}
 
 		function syncPartialClue(letter, src, index) {
+			console.log(`DEBUG: syncPartialClue: letter=${letter}, index=${index}, src.length=${src.length}`);
 			const gridItems = gridMap.get(src[index]);
+			console.log(`DEBUG: syncPartialClue: gridItems=${JSON.stringify(gridItems)}`);
 			const targets = [];
 			for(let i = 0; i < gridItems.length; ++i) {
 				const linkName = gridItems[i].direction[0].toUpperCase() + gridItems[i].number + '-' + gridItems[i].answerPos;
 				targets.push(cluesEl.querySelector('input[data-link-identifier="'+linkName+'"]'));
 			}
 
+			const targetValuesPre = targets.map( target => { return target.value; } );
+
 			Array.from(targets).forEach((target) => {
 				target.value = letter.substr(0,1);
 				updateScreenReaderAnswer(target);
 			});
+
+			const targetValuesPost = targets.map( target => { return target.value; } );
+
+			console.log(`DEBUG: syncPartialClue: targetValuesPre=${JSON.stringify(targetValuesPre)}, targetValuesPost=${JSON.stringify(targetValuesPost)}`);
+
 		}
 
 		const saveLocal = function saveLocal() {

--- a/src/js/oCrossword.js
+++ b/src/js/oCrossword.js
@@ -557,7 +557,7 @@ OCrossword.prototype.assemble = function assemble() {
 			const magicInputValue = magicInput.value;
 			const isAndroidTF = isAndroid();
 
-			console.log(`DEBUG: this.addEventListener: magicInput: isAndroidTF=${JSON.stringify(isAndroidTF)}, shiftKey=${JSON.stringify(shiftKey)}, keyCode=${keyCode}, magicInputValue=${JSON.stringify(magicInputValue)}`);
+			// console.log(`DEBUG: this.addEventListener: magicInput: isAndroidTF=${JSON.stringify(isAndroidTF)}, shiftKey=${JSON.stringify(shiftKey)}, keyCode=${keyCode}, magicInputValue=${JSON.stringify(magicInputValue)}`);
 			if (!isAndroid()) {
 				e.preventDefault();
 			}
@@ -616,7 +616,7 @@ OCrossword.prototype.assemble = function assemble() {
 						}
 					}); //a11y fix for screen reader
 				} else {
-					console.log(`DEBUG: this.addEventListener: magicInput: else: fudging for android ...`);
+					// console.log(`DEBUG: this.addEventListener: magicInput: else: fudging for android ...`);
 
 				}
 
@@ -625,7 +625,7 @@ OCrossword.prototype.assemble = function assemble() {
 
 				progress();
 			} else {
-				console.log(`DEBUG: this.addEventListener: magicInput: else: no keypress match ...`);
+				// console.log(`DEBUG: this.addEventListener: magicInput: else: no keypress match ...`);
 
 			}
 		});
@@ -636,7 +636,7 @@ OCrossword.prototype.assemble = function assemble() {
 				 prevValueForClueCellById[inputID] = '';
 			}
 
-			console.log(`DEBUG: this.addEventListener: cluesEl: inputID=${inputID}, isAndroid=${JSON.stringify(isAndroid())}, e: shiftKey=${JSON.stringify(e.shiftKey)}, keyCode=${e.keyCode},  prevValueForClueCellById[inputID]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
+			// console.log(`DEBUG: this.addEventListener: cluesEl: inputID=${inputID}, isAndroid=${JSON.stringify(isAndroid())}, e: shiftKey=${JSON.stringify(e.shiftKey)}, keyCode=${e.keyCode},  prevValueForClueCellById[inputID]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
 			let timer = 0;
 
 			if (!isAndroid()) {
@@ -648,7 +648,7 @@ OCrossword.prototype.assemble = function assemble() {
 			}
 
 			if(e.target.nodeName !== 'INPUT') {
-				console.log(`DEBUG: this.addEventListener: cluesEl: e.target.nodeName=${JSON.stringify(e.target.nodeName)}`);
+				// console.log(`DEBUG: this.addEventListener: cluesEl: e.target.nodeName=${JSON.stringify(e.target.nodeName)}`);
 				if(e.keyCode === 9) {
 					if(e.shiftKey) {
 						--currentClue;
@@ -726,7 +726,7 @@ OCrossword.prototype.assemble = function assemble() {
 				if(!isAndroid()) {
 					e.target.value = String.fromCharCode(e.keyCode);
 				} else {
-					console.log(`DEBUG: this.addEventListener: cluesEl: keycodes65-90, isAndroid=true, e.target.value=${JSON.stringify(e.target.value)}`);
+					// console.log(`DEBUG: this.addEventListener: cluesEl: keycodes65-90, isAndroid=true, e.target.value=${JSON.stringify(e.target.value)}`);
 				}
 
 				e.target.select();
@@ -737,8 +737,7 @@ OCrossword.prototype.assemble = function assemble() {
 
 				setTimeout(function(){
 					let direction = 1;
-					console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: start:           e.target.value=${JSON.stringify(e.target.value)}, direction=${direction},  prevValueForClueCellById[${inputID}]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
-					// const direction = (isAndroid() && e.target.value == '')? -1 : 1;
+					// console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: start:           e.target.value=${JSON.stringify(e.target.value)}, direction=${direction},  prevValueForClueCellById[${inputID}]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
 					if ( isAndroid() ) {
 						if (
 							 e.target.value ===  prevValueForClueCellById[inputID]
@@ -748,25 +747,25 @@ OCrossword.prototype.assemble = function assemble() {
 							e.target.value = '';
 							direction = -1;
 						}
-						console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: isAndroid, so...: e.target.value=${JSON.stringify(e.target.value)}, direction=${direction},  prevValueForClueCellById[${inputID}]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
+						// console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: isAndroid, so...: e.target.value=${JSON.stringify(e.target.value)}, direction=${direction},  prevValueForClueCellById[${inputID}]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
 					}
 
-					console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: start:           e.target.value=${JSON.stringify(e.target.value)}, direction=${direction},  prevValueForClueCellById[${inputID}]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
+					// console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: start:           e.target.value=${JSON.stringify(e.target.value)}, direction=${direction},  prevValueForClueCellById[${inputID}]=${JSON.stringify( prevValueForClueCellById[inputID])}`);
 					nextInput(e.target, direction);
-					console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: after nextInput: e.target.value=${JSON.stringify(e.target.value)}`);
+					// console.log(`DEBUG: this.addEventListener: cluesEl: setTimeout: after nextInput: e.target.value=${JSON.stringify(e.target.value)}`);
 					updateInBackground(e);
 					 prevValueForClueCellById[inputID] = e.target.value;
 				}, timer);
 
 
 			} else {
-				console.log(`DEBUG: this.addEventListener: cluesEl: else: no keypress match ...`);
+				// console.log(`DEBUG: this.addEventListener: cluesEl: else: no keypress match ...`);
 			}
 		});
 
 		function updateInBackground(e) {
 			getCellFromClue(e.target, gridSync => {
-				console.log(`DEBUG: updateInBackground: getCellFromClue: gridSync=${JSON.stringify(gridSync)}, e.target.value='${e.target.value}'`);
+				// console.log(`DEBUG: updateInBackground: getCellFromClue: gridSync=${JSON.stringify(gridSync)}, e.target.value='${e.target.value}'`);
 				gridSync.grid.textContent = e.target.value;
 
 				if(gridSync.defSync) {
@@ -780,7 +779,7 @@ OCrossword.prototype.assemble = function assemble() {
 		}
 
 		const progress = debounce(function progress(direction=1) {
-			console.log(`DEBUG: progress: direction=${JSON.stringify(direction)}, magicInputTargetEl=${magicInputTargetEl}, magicInputNextEls=${magicInputNextEls}`);
+			// console.log(`DEBUG: progress: direction=${JSON.stringify(direction)}, magicInputTargetEl=${magicInputTargetEl}, magicInputNextEls=${magicInputNextEls}`);
 			direction = direction === -1 ? -1 : 1;
 			const oldMagicInputEl = magicInputTargetEl;
 			const magicInputValueAsSet = magicInput.value;
@@ -798,7 +797,7 @@ OCrossword.prototype.assemble = function assemble() {
 				const index = magicInputNextEls.indexOf(oldMagicInputEl);
 				syncPartialClue(magicInput.value, magicInputNextEls, index);
 				if (isAndroid() && magicInputValueAsSet === '') { // cos this is the sign that the android keyboard entry was a 'delete' key
-					console.log(`DEBUG: progress: after syncPartialClue: magicInputValueAsSet=${JSON.stringify(magicInputValueAsSet)}, so setting direction from ${JSON.stringify(direction)} to -1`);
+					// console.log(`DEBUG: progress: after syncPartialClue: magicInputValueAsSet=${JSON.stringify(magicInputValueAsSet)}, so setting direction from ${JSON.stringify(direction)} to -1`);
 					direction = -1;
 				}
 				if (magicInputNextEls[index + direction]) {
@@ -871,15 +870,15 @@ OCrossword.prototype.assemble = function assemble() {
 			const inputGroup = document.querySelectorAll('input[data-link-identifier^="' + inputID.split('-')[0] +'-"]');
 			const currentInput = parseInt(inputID.split('-')[1]);
 			const newInput = direction === 1?(currentInput+1):(currentInput-1);
-			console.log(`DEBUG: nextInput: inputID=${JSON.stringify(inputID)}, direction=${direction}, currentInput=${currentInput}, newInput=${newInput}, inputGroup.length=${inputGroup.length}`);
+			// console.log(`DEBUG: nextInput: inputID=${JSON.stringify(inputID)}, direction=${direction}, currentInput=${currentInput}, newInput=${newInput}, inputGroup.length=${inputGroup.length}`);
 
 			if(newInput >= 0 && newInput < inputGroup.length) {
-				console.log(`DEBUG: nextInput: next.focus and next.select`);
+				// console.log(`DEBUG: nextInput: next.focus and next.select`);
 				const next = cluesEl.querySelector('input[data-link-identifier="' + inputID.split('-')[0] +'-'+ newInput+'"]');
 				next.focus();
 				next.select();
 			} else {
-				console.log(`DEBUG: nextInput: source.blur`);
+				// console.log(`DEBUG: nextInput: source.blur`);
 				source.blur();
 				const def = source.parentElement.parentElement;
 				const inputs = cluesEl.querySelectorAll('input');
@@ -937,7 +936,7 @@ OCrossword.prototype.assemble = function assemble() {
 			const defDirection = inputIdentifier.slice(0,1) === 'A'?'across':'down';
 			const defNum = inputIdentifier.slice(1,inputIdentifier.length).split('-')[0];
 			const defIndex = parseInt(inputIdentifier.split('-')[1], 10);
-			console.log(`DEBUG: getCellFromClue: inputIdentifier=${inputIdentifier}, defDirection=${defDirection}, defNum=${defNum}, defIndex=${defIndex}`);
+			// console.log(`DEBUG: getCellFromClue: inputIdentifier=${inputIdentifier}, defDirection=${defDirection}, defNum=${defNum}, defIndex=${defIndex}`);
 
 			const selectedCell = {};
 
@@ -958,7 +957,7 @@ OCrossword.prototype.assemble = function assemble() {
 				}
 			}
 
-			console.log(`DEBUG: getCellFromClue: selectedCell=${JSON.stringify(selectedCell)}`);
+			// console.log(`DEBUG: getCellFromClue: selectedCell=${JSON.stringify(selectedCell)}`);
 
 			callback(selectedCell);
 		}
@@ -1068,9 +1067,9 @@ OCrossword.prototype.assemble = function assemble() {
 
 		function syncPartialClue(letter, src, index) {
 			const newValue = letter.substr(0,1);
-			console.log(`DEBUG: syncPartialClue: letter=${letter}, newValue=${newValue}, index=${index}, src.length=${src.length}`);
+			// console.log(`DEBUG: syncPartialClue: letter=${letter}, newValue=${newValue}, index=${index}, src.length=${src.length}`);
 			const gridItems = gridMap.get(src[index]);
-			console.log(`DEBUG: syncPartialClue: gridItems=${JSON.stringify(gridItems)}`);
+			// console.log(`DEBUG: syncPartialClue: gridItems=${JSON.stringify(gridItems)}`);
 
 			const targetIds = [];
 			for(let i = 0; i < gridItems.length; ++i) {
@@ -1091,7 +1090,7 @@ OCrossword.prototype.assemble = function assemble() {
 				prevValueForClueCellById[id] = newValue; // for use when handling clue cells
 			})
 
-			console.log(`DEBUG: syncPartialClue: targetIds=${JSON.stringify(targetIds)}, targetValuesPre=${JSON.stringify(targetValuesPre)}, targetValuesPost=${JSON.stringify(targetValuesPost)}`);
+			// console.log(`DEBUG: syncPartialClue: targetIds=${JSON.stringify(targetIds)}, targetValuesPre=${JSON.stringify(targetValuesPre)}, targetValuesPost=${JSON.stringify(targetValuesPost)}`);
 		}
 
 		const saveLocal = function saveLocal() {


### PR DESCRIPTION
That damn android keyboard and the 229 keyCode on addEventListener 'keydown'!

Lots of nastiness going on there. Android returns the same keycode (229) for a variety of different keys being pressed. The main symptom was space and delete not working at all sensibly.

This fix attempts to put a large sticking plaster over the whole mess, and it is a mess. By keeping a record of what the letter was before android silently alters it (or not) and returns a useful keycode (or not), it is very nearly possible to deduce what key was pressed and act accordingly. What makes this more complex is the interaction/overlap between the same letter cell appearing multiple times in different clues and on the grid.

There should now be semi-sensible behaviour on smartphone/android, in both the grid and clue views, where the delete key deletes the current letter and steps left (or up) one, and the space bar deletes the current letter and steps right (or down) one.

This differs from desktop mode (and iOS), where the space bar does *not* delete the letter before moving on one step.

For more info on what the underlying problem is, just google for 'android keyboard 229'.

The proper fix is a full rewrite and that is being contemplated.